### PR TITLE
Tooling improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ endif()
 
 set(SOURCE_FILES
         src/tools/imgui_demo_tool.cpp
+        src/tools/porytiles_tool.cpp
         src/main.cpp
         src/application.cpp
         src/imgui_utils.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(SOURCE_FILES
         src/trainers/mons/mon_editor.cpp
         src/game_settings.cpp
         src/trainers/mons/mon_data.cpp
-        src/shortcuts/shortcuts.cpp
+        src/tools/shortcuts_tool.cpp
         src/string_parsing_util.cpp
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ if(WIN32)
 endif()
 
 set(SOURCE_FILES
+        src/tools/imgui_demo_tool.cpp
         src/main.cpp
         src/application.cpp
         src/imgui_utils.cpp

--- a/include/game_loaders.hpp
+++ b/include/game_loaders.hpp
@@ -40,15 +40,20 @@ public:
     std::vector<std::string> names {};
 };
 
-struct GameLoaders {
-    AbilityLoader abilities;
-    ItemLoader items;
-    MoveLoader moves;
-    NatureLoader natures;
-    BallLoader balls;
-    SpeciesLoader species;
-};
+#define DECLARE_GAME_LOADER(loader, name) private: loader m_##name; bool m_##name##AreLoaded; public: loader & get##loader ();
 
-GameLoaders createLoaders(const std::filesystem::path& projectPath);
+class GameLoaders {
+    DECLARE_GAME_LOADER(AbilityLoader, abilities)
+    DECLARE_GAME_LOADER(ItemLoader, items)
+    DECLARE_GAME_LOADER(MoveLoader, moves)
+    DECLARE_GAME_LOADER(NatureLoader, natures)
+    DECLARE_GAME_LOADER(BallLoader, balls)
+    DECLARE_GAME_LOADER(SpeciesLoader, species)
+
+private:
+    std::filesystem::path m_projectPath;
+public:
+    void init(std::filesystem::path projectPath);
+};
 
 #endif

--- a/include/pokedev_tool.hpp
+++ b/include/pokedev_tool.hpp
@@ -1,0 +1,13 @@
+#ifndef POKEDEV_TOOL_HPP
+#define POKEDEV_TOOL_HPP
+
+class PokeDevTool
+{
+public:
+    virtual ~PokeDevTool() {};
+    virtual void renderWindow() = 0;
+    const char* name;
+    bool isActive;
+};
+
+#endif // POKEDEV_TOOL_HPP

--- a/include/tools/imgui_demo_tool.hpp
+++ b/include/tools/imgui_demo_tool.hpp
@@ -1,0 +1,13 @@
+#ifndef POKEDEV_IMGUI_DEMO_TOOL_HPP
+#define POKEDEV_IMGUI_DEMO_TOOL_HPP
+
+#include "pokedev_tool.hpp"
+
+class ImGuiDemoTool : public PokeDevTool
+{
+public:
+    ImGuiDemoTool();
+    void renderWindow() override;
+};
+
+#endif //POKEDEV_IMGUI_DEMO_TOOL_HPP 

--- a/include/tools/porytiles_tool.hpp
+++ b/include/tools/porytiles_tool.hpp
@@ -1,0 +1,21 @@
+#ifndef POKEDEV_PORYTILES_TOOL_HPP
+#define POKEDEV_PORYTILES_TOOL_HPP
+
+#include "pokedev_tool.hpp"
+#include "porytiles/porytiles_gui.hpp"
+
+class PorytilesTool : public PokeDevTool
+{
+public:
+    PorytilesTool(SDL_Renderer* renderer);
+    void renderWindow() override;
+private:
+    PorytilesGui gui {};
+    bool compilePrimaryActive {};
+    bool compileSecondaryActive {};
+    bool decompilePrimaryActive {};
+    bool decompileSecondaryActive {};
+    bool settingsActive {};
+};
+
+#endif // POKEDEV_PORYTILES_TOOL_HPP

--- a/include/tools/shortcuts_tool.hpp
+++ b/include/tools/shortcuts_tool.hpp
@@ -6,6 +6,7 @@
 #include <filesystem>
 
 #include "serializer.hpp"
+#include "pokedev_tool.hpp"
 
 struct Shortcut;
 struct ShortcutGroup;
@@ -30,17 +31,10 @@ struct ShortcutGroup {
     Shortcut* members[MAX_SHORTCUTS_PER_GROUP] {};
 };
 
-struct ShortcutGui {
-    int groupCount {};
-    ShortcutGroup groups[MAX_GROUPS] {};
-
-    int shortcutCount {};
-    Shortcut shortcuts[MAX_SHORTCUTS] {};
-
-    std::filesystem::path shortcutFilePath {};
-
-    void draw(bool& isOpen);
-    void init();
+class ShortcutsTool : public PokeDevTool {
+public:
+    ShortcutsTool();
+    void renderWindow() override;
 
     template<class Archive>
     void serialize(Archive& archive) {
@@ -48,6 +42,13 @@ struct ShortcutGui {
                 AUTO_NAME(shortcutFilePath)
         );
     }
+private:
+    int groupCount {};
+    ShortcutGroup groups[MAX_GROUPS] {};
+    int shortcutCount {};
+    Shortcut shortcuts[MAX_SHORTCUTS] {};
+    std::filesystem::path shortcutFilePath {};
+    void init();
 };
 
 /*

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -4,7 +4,7 @@
 #include "serializer.hpp"
 #include "trainers/mons/mon_editor.hpp"
 #include "game_loaders.hpp"
-#include "shortcuts/shortcuts.hpp"
+#include "tools/shortcuts_tool.hpp"
 #include "pokedev_tool.hpp"
 #include "tools/imgui_demo_tool.hpp"
 
@@ -12,30 +12,25 @@
 
 static struct WindowState {
     bool showSettings{};
-    bool showImGuiDemo{};
     bool showPrimaryCompiler{};
     bool showPrimaryDecompiler{};
     bool showSecondaryCompiler{};
     bool showSecondaryDecompiler{};
-    bool showShortcuts{true};
 
     template <class Archive>
     void serialize(Archive& archive) {
         archive(
             CUSTOM_NAME("showSettings", showSettings),
-            CUSTOM_NAME("showImGuiDemo", showImGuiDemo),
             CUSTOM_NAME("showPrimaryCompilerTool", showPrimaryCompiler),
             CUSTOM_NAME("showSecondaryCompilerTool", showSecondaryCompiler),
             CUSTOM_NAME("showPrimaryDecompilerTool", showPrimaryDecompiler),
-            CUSTOM_NAME("showSecondaryDecompilerTool", showSecondaryDecompiler),
-            CUSTOM_NAME("showShortcuts", showShortcuts)
+            CUSTOM_NAME("showSecondaryDecompilerTool", showSecondaryDecompiler)
         );
     }
 } window;
 
 static ConfigFile s_config{"pokedev_config.json"};
 static PorytilesGui s_porytilesGui{};
-static ShortcutGui s_shortcutGui {};
 
 GameLoaders Application::loaders {};
 GameSettings Application::settings {};
@@ -43,7 +38,7 @@ GameSettings Application::settings {};
 static void reloadConfig() {
     s_config.readData(
         CUSTOM_NAME("porytilesGui", s_porytilesGui),
-        CUSTOM_NAME("shortcutGui", s_shortcutGui),
+        // CUSTOM_NAME("shortcutGui", s_shortcutGui),
         CUSTOM_NAME("windowState", window),
         CUSTOM_NAME("gameSettings", Application::settings)
     );
@@ -52,7 +47,7 @@ static void reloadConfig() {
 static void saveConfig() {
     s_config.writeData(
         CUSTOM_NAME("porytilesGui", s_porytilesGui),
-        CUSTOM_NAME("shortcutGui", s_shortcutGui),
+        // CUSTOM_NAME("shortcutGui", s_shortcutGui),
         CUSTOM_NAME("windowState", window),
         CUSTOM_NAME("gameSettings", Application::settings)
     );
@@ -60,12 +55,12 @@ static void saveConfig() {
 
 static PokeDevTool* s_tools[] {
     new ImGuiDemoTool {},
+    new ShortcutsTool {},
 }; 
 
 void Application::init() {
     //    loaders = createLoaders(settings.projectPath); // todo: slow
     s_porytilesGui.init(Platform::getRenderer());
-    s_shortcutGui.init();
 }
 
 void Application::shutdown() {
@@ -113,7 +108,6 @@ void Application::render() {
             ImGui::MenuItem("Primary Decompiler", nullptr, &window.showPrimaryDecompiler);
             ImGui::MenuItem("Secondary Compiler", nullptr, &window.showSecondaryCompiler);
             ImGui::MenuItem("Secondary Decompiler", nullptr, &window.showSecondaryDecompiler);
-            ImGui::MenuItem("Shortcuts", nullptr, &window.showShortcuts);
             ImGui::EndMenu();
         }
         ImGui::EndMenuBar();
@@ -138,9 +132,6 @@ void Application::render() {
     }
     if (window.showSecondaryDecompiler) {
         s_porytilesGui.drawSecondaryDecompilerWindow(&window.showSecondaryDecompiler);
-    }
-    if (window.showShortcuts) {
-        s_shortcutGui.draw(window.showShortcuts);
     }
     if (window.showSettings && ImGui::Begin("Settings", &window.showSettings)) {
         settings.draw();

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -123,7 +123,7 @@ void Application::render() {
 
     for (int i = 0; i < ARR_LEN(s_tools); ++i) {
         if (s_tools[i]->isActive) {
-            s_tools[i]->renderWindow());
+            s_tools[i]->renderWindow();
         }
     }
 

--- a/src/game_loaders.cpp
+++ b/src/game_loaders.cpp
@@ -3,17 +3,25 @@
 #include "game_loaders.hpp"
 #include "string_parsing_util.hpp"
 
-GameLoaders createLoaders(const std::filesystem::path &projectPath)
-{
-    GameLoaders loaders {};
-    loaders.abilities.init(projectPath / "include/constants/abilities.h");
-    loaders.items.init(projectPath / "include/constants/items.h");
-    loaders.moves.init(projectPath / "include/constants/moves.h");
-    loaders.natures.init(projectPath / "include/constants/pokemon.h");
-    loaders.balls.init(projectPath / "include/constants/items.h");
-    loaders.species.init(projectPath / "include/constants/species.h");
-    return loaders;
+void GameLoaders::init(std::filesystem::path projectPath) {
+    m_projectPath = projectPath;
 }
+
+#define IMPL_GET_LOADER(loader, name, ...) \
+    loader & GameLoaders::get##loader () { \
+        if (! m_##name##AreLoaded ) { \
+            m_##name .init(__VA_ARGS__); \
+            m_##name##AreLoaded = true; \
+        } \
+        return m_##name ; \
+    }\
+
+IMPL_GET_LOADER(AbilityLoader, abilities, m_projectPath / "include/constants/abilities.h")
+IMPL_GET_LOADER(ItemLoader, items, m_projectPath / "include/constants/items.h")
+IMPL_GET_LOADER(MoveLoader, moves, m_projectPath / "include/constants/moves.h")
+IMPL_GET_LOADER(NatureLoader, natures, m_projectPath / "include/constants/pokemon.h")
+IMPL_GET_LOADER(BallLoader, balls, m_projectPath / "include/constants/items.h")
+IMPL_GET_LOADER(SpeciesLoader, species, m_projectPath / "include/constants/species.h")
 
 void AbilityLoader::init(const std::filesystem::path& abilityFilePath) {
     names = parseDefines(abilityFilePath, ".*#define ABILITY_");

--- a/src/tools/imgui_demo_tool.cpp
+++ b/src/tools/imgui_demo_tool.cpp
@@ -6,5 +6,5 @@ ImGuiDemoTool::ImGuiDemoTool() {
 }
 
 void ImGuiDemoTool::renderWindow() {
-    ImGui::ShowDemoWindow(isActive);
+    ImGui::ShowDemoWindow(&isActive);
 }

--- a/src/tools/imgui_demo_tool.cpp
+++ b/src/tools/imgui_demo_tool.cpp
@@ -1,0 +1,10 @@
+#include "tools/imgui_demo_tool.hpp"
+#include "imgui.h"
+
+ImGuiDemoTool::ImGuiDemoTool() {
+    name = "ImGui Demo";
+}
+
+void ImGuiDemoTool::renderWindow() {
+    ImGui::ShowDemoWindow(isActive);
+}

--- a/src/tools/porytiles_tool.cpp
+++ b/src/tools/porytiles_tool.cpp
@@ -1,0 +1,32 @@
+#include "tools/porytiles_tool.hpp"
+#include "imgui.h"
+
+PorytilesTool::PorytilesTool(SDL_Renderer* renderer) {
+    name = "Porytiles";
+    gui.init(renderer);
+}
+
+#define RENDER_SUB_WINDOW(name, isActive, renderFunc) \
+    if (ImGui::Button(name)) { \
+        isActive = true; \
+    } \
+    if (isActive) {\
+        gui.renderFunc(&isActive); \
+    }\
+
+void PorytilesTool::renderWindow() {
+    RENDER_SUB_WINDOW("Open Primary Compiler", compilePrimaryActive, drawPrimaryCompilerWindow)
+    RENDER_SUB_WINDOW("Open Secondary Compiler", compileSecondaryActive, drawSecondaryCompilerWindow)
+    RENDER_SUB_WINDOW("Open Primary Decompiler", decompilePrimaryActive, drawPrimaryDecompilerWindow)
+    RENDER_SUB_WINDOW("Open Secondary Decompiler", decompileSecondaryActive, drawSecondaryDecompilerWindow)
+
+    if (ImGui::Button("Open Settings")) {
+        settingsActive = true;
+    }
+    if (settingsActive) {
+        if (ImGui::Begin("Porytiles Settings", &settingsActive)) {
+            gui.drawSettings();
+            ImGui::End();
+        }
+    }
+}

--- a/src/tools/shortcuts_tool.cpp
+++ b/src/tools/shortcuts_tool.cpp
@@ -1,13 +1,18 @@
 #include <fstream>
 #include <string>
 #include <imgui.h>
-#include "shortcuts/shortcuts.hpp"
+#include "tools/shortcuts_tool.hpp"
 #include "string_parsing_util.hpp"
 #include "platform.hpp"
 #include "application.hpp"
 #include "imgui_utils.hpp"
 
-void ShortcutGui::init() {
+ShortcutsTool::ShortcutsTool() {
+    name = "Shortcuts";
+    init();
+}
+
+void ShortcutsTool::init() {
     std::ifstream shortcutFileStream {shortcutFilePath};
 
     if (!shortcutFileStream.is_open()) {
@@ -69,8 +74,8 @@ void ShortcutGui::init() {
     }
 }
 
-void ShortcutGui::draw(bool& isOpen) {
-    if (ImGui::Begin("Shortcuts", &isOpen)) {
+void ShortcutsTool::renderWindow() {
+    if (ImGui::Begin("Shortcuts", &isActive)) {
         ImGuiUtils::filePicker("Shortcut File", shortcutFilePath, {});
 
         if (ImGui::Button("Reload")) {

--- a/src/trainers/mons/mon_data.cpp
+++ b/src/trainers/mons/mon_data.cpp
@@ -5,7 +5,7 @@
 std::string MonData::generateStruct() const {
     std::string result = "    {\n";
 
-    result += fmt::format("        .species = {},\n", Application::loaders.species.names[speciesIndex]);
+    result += fmt::format("        .species = {},\n", Application::loaders.getSpeciesLoader().names[speciesIndex]);
     result += fmt::format("        .lvl = {},\n", level);
 
     if (hasNickname) {
@@ -27,23 +27,23 @@ std::string MonData::generateStruct() const {
         result += fmt::format("        .ev = TRAINER_PARTY_IVS({}, {}, {}, {}, {}, {}),\n", ivs[0], ivs[1], ivs[2], ivs[3], ivs[4], ivs[5]);
     }
     if (hasAbility) {
-        result += fmt::format("        .ability = {},\n", Application::loaders.abilities.names[abilityIndex]);
+        result += fmt::format("        .ability = {},\n", Application::loaders.getAbilityLoader().names[abilityIndex]);
     }
     if (hasBall) {
-        result += fmt::format("        .ball = {},\n", Application::loaders.balls.names[ballIndex]);
+        result += fmt::format("        .ball = {},\n", Application::loaders.getBallLoader().names[ballIndex]);
     }
     if (hasItem) {
-        result += fmt::format("        .heldItem = {},\n", Application::loaders.items.names[itemIndex]);
+        result += fmt::format("        .heldItem = {},\n", Application::loaders.getItemLoader().names[itemIndex]);
     }
     if (hasNature) {
-        result += fmt::format("        .nature = TRAINER_PARTY_NATURE({}),\n", Application::loaders.natures.names[natureIndex]);
+        result += fmt::format("        .nature = TRAINER_PARTY_NATURE({}),\n", Application::loaders.getNatureLoader().names[natureIndex]);
     }
     if (hasMoves) {
         result += fmt::format("        .moves = {{\n            {},\n            {},\n            {},\n            {}\n        }},\n",
-                              Application::loaders.moves.names[movesIndex[0]],
-                              Application::loaders.moves.names[movesIndex[1]],
-                              Application::loaders.moves.names[movesIndex[2]],
-                              Application::loaders.moves.names[movesIndex[3]]
+                              Application::loaders.getMoveLoader().names[movesIndex[0]],
+                              Application::loaders.getMoveLoader().names[movesIndex[1]],
+                              Application::loaders.getMoveLoader().names[movesIndex[2]],
+                              Application::loaders.getMoveLoader().names[movesIndex[3]]
         );
     }
 

--- a/src/trainers/mons/mon_editor.cpp
+++ b/src/trainers/mons/mon_editor.cpp
@@ -8,15 +8,15 @@ using namespace Application;
 
 void MonEditor::init()
 {
-    m_abilityCombo.init(&loaders.abilities.names, "Abilities");
-    m_itemCombo.init(&loaders.items.names, "Items");
-    m_move1Combo.init(&loaders.moves.names, "##Move 1");
-    m_move2Combo.init(&loaders.moves.names, "##Move 2");
-    m_move3Combo.init(&loaders.moves.names, "##Move 3");
-    m_move4Combo.init(&loaders.moves.names, "##Move 4");
-    m_natureCombo.init(&loaders.natures.names, "Nature");
-    m_ballCombo.init(&loaders.balls.names, "Ball");
-    m_speciesCombo.init(&loaders.species.names, "Species");
+    m_abilityCombo.init(&loaders.getAbilityLoader().names, "Abilities");
+    m_itemCombo.init(&loaders.getItemLoader().names, "Items");
+    m_move1Combo.init(&loaders.getMoveLoader().names, "##Move 1");
+    m_move2Combo.init(&loaders.getMoveLoader().names, "##Move 2");
+    m_move3Combo.init(&loaders.getMoveLoader().names, "##Move 3");
+    m_move4Combo.init(&loaders.getMoveLoader().names, "##Move 4");
+    m_natureCombo.init(&loaders.getNatureLoader().names, "Nature");
+    m_ballCombo.init(&loaders.getBallLoader().names, "Ball");
+    m_speciesCombo.init(&loaders.getSpeciesLoader().names, "Species");
     setDataToEdit(nullptr);
 }
 

--- a/src/trainers/trainer_editor.cpp
+++ b/src/trainers/trainer_editor.cpp
@@ -21,7 +21,7 @@ void TrainerEditor::draw() {
     if (ImGui::BeginListBox("Party Members")) {
         for (int i = 0; i < m_data->partyMemberCount; i++) {
             ImGui::PushID(i);
-            const char* speciesName = Application::loaders.species.names[m_data->partyMembers[i].speciesIndex].c_str();
+            const char* speciesName = Application::loaders.getSpeciesLoader().names[m_data->partyMembers[i].speciesIndex].c_str();
             if (ImGui::Selectable(speciesName, m_editedPartyMemberIndex == i)) {
                 m_editedPartyMemberIndex = i;
                 m_monEditor.setDataToEdit(&m_data->partyMembers[i]);


### PR DESCRIPTION
Made attempts to ease the process of adding new tools.

Previously, you needed to edit `application.cpp` in several locations to integrate the taskbar, main rendering, ect.
Now, you just need your tool to extend the `PokeDevTool` class, initialize a suitable c-string name and draw method, and `push_back` into the `s_tools` vector in `application.cpp`.

This is part of a larger attempt to clean up the `application.cpp` class and friends - things that are still on the todo list are cleaning up the settings and serialization stuff.

